### PR TITLE
Added support for POST /api/v1/buttons/:code/create_order

### DIFF
--- a/lib/Coinbase/Coinbase.php
+++ b/lib/Coinbase/Coinbase.php
@@ -188,6 +188,11 @@ class Coinbase
         return $returnValue;
     }
 
+    public function createOrderFromButtonCode($buttonCode)
+    {
+        return $this->post("buttons/" . $buttonCode . "/create_order");
+    }
+
     public function createUser($email, $password)
     {
         return $this->post("users", array(


### PR DESCRIPTION
Howdy.

I added support for POST /api/v1/buttons/:code/create_order

See https://coinbase.com/api/doc/1.0/buttons/create_order.html for more info. 

All tests pass.
