### PR TITLE
Added support for authentication objects.  

### DIFF
--- a/lib/Coinbase.php
+++ b/lib/Coinbase.php
@@ -12,3 +12,7 @@ require_once(dirname(__FILE__) . '/Coinbase/Requestor.php');
 require_once(dirname(__FILE__) . '/Coinbase/Rpc.php');
 require_once(dirname(__FILE__) . '/Coinbase/OAuth.php');
 require_once(dirname(__FILE__) . '/Coinbase/TokensExpiredException.php');
+require_once(dirname(__FILE__) . '/Coinbase/Authentication.php');
+require_once(dirname(__FILE__) . '/Coinbase/SimpleApiKeyAuthentication.php');
+require_once(dirname(__FILE__) . '/Coinbase/OAuthAuthentication.php');
+require_once(dirname(__FILE__) . '/Coinbase/ApiKeyAuthentication.php');

--- a/lib/Coinbase/ApiKeyAuthentication.php
+++ b/lib/Coinbase/ApiKeyAuthentication.php
@@ -1,0 +1,21 @@
+<?php
+
+class Coinbase_ApiKeyAuthentication extends Coinbase_Authentication
+{
+    private $_apiKey;
+    private $_apiKeySecret;
+
+    public function __construct($apiKey, $apiKeySecret)
+    {
+        $this->_apiKey = $apiKey;
+        $this->_apiKeySecret = $apiKeySecret;
+    }
+
+    public function getData()
+    {
+        $data = new stdClass();
+        $data->apiKey = $this->_apiKey;
+        $data->apiKeySecret = $this->_apiKeySecret;
+        return $data;
+    }
+}

--- a/lib/Coinbase/Authentication.php
+++ b/lib/Coinbase/Authentication.php
@@ -1,0 +1,6 @@
+<?php
+
+abstract class Coinbase_Authentication
+{
+    abstract public function getData();
+}

--- a/lib/Coinbase/Coinbase.php
+++ b/lib/Coinbase/Coinbase.php
@@ -3,76 +3,59 @@
 class Coinbase
 {
     const API_BASE = 'https://coinbase.com/api/v1/';
-
-    // Authentication
-    private $_useOauth = false;
-    private $_useSimpleApiKey = false;
-    private $_apiKey = null;
-    private $_oauthObject = null;
-    private $_tokens = null;
-
     private $_rpc;
+    private $_authentication;
+
 
     public static function withApiKey($key, $secret)
     {
-        $coinbase = new Coinbase(null);
-        $coinbase->_useOauth = false;
-        $coinbase->_useSimpleApiKey = false;
-        $coinbase->_apiKey = array($key, $secret);
-        return $coinbase;
+        return new Coinbase(new Coinbase_ApiKeyAuthentication($key, $secret));
     }
 
     public static function withSimpleApiKey($key)
     {
-        $coinbase = new Coinbase(null);
-        $coinbase->_useOauth = false;
-        $coinbase->_useSimpleApiKey = true;
-        $coinbase->_apiKey = $key;
-        return $coinbase;
+        return new Coinbase(new Coinbase_SimpleApiKeyAuthentication($key));
     }
 
     public static function withOAuth($oauth, $tokens)
     {
-        $coinbase = new Coinbase(null);
-        $coinbase->_useOauth = true;
-        $coinbase->_useSimpleApiKey = false;
-        $coinbase->_oauthObject = $oauth;
-        $coinbase->_tokens = $tokens;
-        return $coinbase;
+        return new Coinbase(new Coinbase_OAuthAuthentication($oauth, $tokens));
     }
 
     // This constructor is deprecated.
-    public function __construct($apiKeyOrOauth, $tokens=null)
+    public function __construct($authentication, $tokens=null, $apiKeySecret=null)
     {
-        if ($tokens !== null) {
-            // OAuth
-            $this->_useOauth = true;
-            $this->_oauthObject = $apiKeyOrOauth;
-            $this->_tokens = $tokens;
-        } else if ($apiKeyOrOauth !== null) {
-            // Simple API key
-            $this->_apiKey = $apiKeyOrOauth;
-            $this->_useSimpleApiKey = true;
+        // First off, check for a legit authentication class type
+        if (is_a($authentication, 'Coinbase_Authentication')) {
+            $this->_authentication = $authentication;
+        } else {
+            // Here, $authentication was not a valid authentication object, so
+            // analyze the constructor parameters and return the correct object.
+            // This should be considered deprecated, but it's here for backward compatibility.
+            // In older versions of this library, the first parameter of this constructor
+            // can be either an API key string or an OAuth object.
+            if ($tokens !== null) {
+                $this->_authentication = new Coinbase_OAuthAuthentication($authentication, $tokens);
+            } else if ($authentication !== null && is_string($authentication)) {
+                $apiKey = $authentication;
+                if ($apiKeySecret === null) {
+                    // Simple API key
+                    $this->_authentication = new Coinbase_SimpleApiKeyAuthentication($apiKey);
+                } else {
+                    $this->_authentication = new Coinbase_ApiKeyAuthentication($apiKey, $apiKeySecret);
+                }
+            } else {
+                throw new Coinbase_ApiException('Could not determine API authentication scheme');
+            }
         }
 
-        $this->_rpc = new Coinbase_Rpc(new Coinbase_Requestor(), $this);
-    }
-
-    public function getAuthenticationData()
-    {
-        $data = new stdClass();
-        $data->useSimpleApiKey = $this->_useSimpleApiKey;
-        $data->useOauth = $this->_useOauth;
-        $data->apiKey = $this->_apiKey;
-        $data->oauthObject = $this->_oauthObject;
-        $data->tokens = $this->_tokens;
-        return $data;
+        $this->_rpc = new Coinbase_Rpc(new Coinbase_Requestor(), $this->_authentication);
     }
 
     // Used for unit testing only
     public function setRequestor($requestor)
     {
-        $this->_rpc = new Coinbase_Rpc($requestor, $this);
+        $this->_rpc = new Coinbase_Rpc($requestor, $this->_authentication);
         return $this;
     }
 

--- a/lib/Coinbase/OAuthAuthentication.php
+++ b/lib/Coinbase/OAuthAuthentication.php
@@ -1,0 +1,21 @@
+<?php
+
+class Coinbase_OAuthAuthentication extends Coinbase_Authentication
+{
+    private $_oauth;
+    private $_tokens;
+
+    public function __construct($oauth, $tokens)
+    {
+        $this->_oauth = $oauth;
+        $this->_tokens = $tokens;
+    }
+
+    public function getData()
+    {
+        $data = new stdClass();
+        $data->oauth = $this->_oauth;
+        $data->tokens = $this->_tokens;
+        return $data;
+    }
+}

--- a/lib/Coinbase/SimpleApiKeyAuthentication.php
+++ b/lib/Coinbase/SimpleApiKeyAuthentication.php
@@ -1,0 +1,18 @@
+<?php
+
+class Coinbase_SimpleApiKeyAuthentication extends Coinbase_Authentication
+{
+    private $_apiKey;
+
+    public function __construct($apiKey)
+    {
+        $this->_apiKey = $apiKey;
+    }
+
+    public function getData()
+    {
+        $data = new stdClass();
+        $data->apiKey = $this->_apiKey;
+        return $data;
+    }
+}

--- a/test/Coinbase.php
+++ b/test/Coinbase.php
@@ -575,4 +575,16 @@ class TestOfCoinbase extends UnitTestCase {
         $this->assertEqual($response->transactions[0]->id, '5018f833f8182b129c00002f');
         $this->assertEqual($response->transactions[1]->id, '5018f833f8182b129c00002e');
     }
+
+    function testInvalidAuthenticationObjectThrowsException()
+    {
+        try {
+            $invalidAuthenticationObject = new stdClass();
+            $invalidAuthenticationObject->foo = "bar";
+            $coinbase = new Coinbase($invalidAuthenticationObject);
+            $this->fail('Expected Coinbase_ApiException to be thrown, but it was not.');
+        } catch (Coinbase_ApiException $e) {
+            $this->assertEqual($e->getMessage(), 'Could not determine API authentication scheme');
+        }
+    }
 }


### PR DESCRIPTION
Hey there,

This is my take on the new Coinbase API authentication mechanisms. 

It replaces all the boolean logic (isSimpleKey, isOAuth, etc) with authentication classes.

With these changes, Coinbase can add additional authentication mechanisms if they need, without having to add more layers of flags/booleans.

Cheers!
