### PR TITLE
Fixed URL for API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,3 +290,10 @@ For this reason, API access is disabled on all Coinbase accounts by default.  If
 ## Testing
 
 If you'd like to contribute code or modify this library, you can run the test suite by executing `/path/to/coinbase-php/test/Coinbase.php` in a web browser or on the command line with `php`.
+
+First, init the submodule from the root of the repo using these commands:
+    
+    git submodule init
+    git submodule sync
+    git submodule update
+


### PR DESCRIPTION
Updated the URL to for API Keys in user's Coinbase account
