### PR TITLE
Update API_BASE URL

### DIFF
--- a/lib/Coinbase/Coinbase.php
+++ b/lib/Coinbase/Coinbase.php
@@ -2,7 +2,7 @@
 
 class Coinbase
 {
-    const API_BASE = 'https://coinbase.com/api/v1/';
+    const API_BASE = 'https://api.coinbase.com/v1/';
     private $_rpc;
     private $_authentication;
 


### PR DESCRIPTION
Old URL was deprecated, updated to new one based on information found in the API Endpoints section of Coinbase's API overview (https://www.coinbase.com/docs/api/overview)
