### PR TITLE
#fix HttpException bug.

### DIFF
--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -74,9 +74,9 @@ class HttpException extends RuntimeException
     }
 
     /** @return Error[] */
-    private static function errors(ResponseInterface $response)
+    private static function errors(ResponseInterface $response = null)
     {
-        $data = json_decode($response->getBody(), true);
+        $data = $response ? json_decode($response->getBody(), true) : null;
 
         if (isset($data['errors'])) {
             // api errors


### PR DESCRIPTION
While working with your library I encountered this bug 

> Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Argument 1 passed to Coinbase\Wallet\Exception\HttpException::errors() must be an instance of Psr\Http\Message\ResponseInterface, null given, called in C:\laragon\www\app\vendor\coinbase\coinbase\src\Exception\HttpException.php on line 29 in C:\laragon\www\app\vendor\coinbase\coinbase\src\Exception\HttpException.php:77


The problem starts in the HttpException class here :

```
    public static function wrap(RequestException $e)
    {
        $response = $e->getResponse();
        //...
    }
```

$e is an instance of RequestException, and RequestException->getResponse() returns either ResponseInterface OR null as seen in the RequestException class DocBlock:

```
 /**
     * Get the associated response
     *
     * @return ResponseInterface|null
     */
    public function getResponse()
    {
        return $this->response;
    }
```
 
 
But later on in the HttpException class you do not account for a null value which causes the bug.

```
    /** @return Error[] */
    private static function errors(ResponseInterface $response)
    {
        //...
    }
```