### PR TITLE
Updates for ETH launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ $rates = $client->getExchangeRates();
 **Buy price**
 
 ```php
-$buyPrice = $client->getBuyPrice();
+$buyPrice = $client->getBuyPrice('BTC-USD');
 ```
 
 **Sell price**

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ $sellPrice = $client->getSellPrice('BTC-USD');
 **Spot price**
 
 ```php
-$spotPrice = $client->getSpotPrice();
+$spotPrice = $client->getSpotPrice('BTC-USD');
 ```
 
 **Current server time**

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ $buyPrice = $client->getBuyPrice();
 **Sell price**
 
 ```php
-$sellPrice = $client->getSellPrice();
+$sellPrice = $client->getSellPrice('BTC-USD');
 ```
 
 **Spot price**

--- a/src/Client.php
+++ b/src/Client.php
@@ -127,11 +127,15 @@ class Client
 
     public function getSpotPrice($currency = null, array $params = [])
     {
-        if ($currency) {
-            $params['currency'] = $currency;
+        if (strpos($currency, '-') !== false) {
+            $pair = $currency;
+        } else if ($currency) {
+            $pair = 'BTC-' . $currency;
+        } else {
+            $pair = 'BTC-USD';
         }
 
-        return $this->getAndMapMoney('/v2/prices/spot', $params);
+        return $this->getAndMapMoney('/v2/prices/' . $pair . '/spot', $params);
     }
 
     public function getHistoricPrices($currency = null, array $params = [])

--- a/src/Client.php
+++ b/src/Client.php
@@ -105,11 +105,17 @@ class Client
 
     public function getBuyPrice($currency = null, array $params = [])
     {
-        if ($currency) {
-            $params['currency'] = $currency;
+        // If AAA-BBB format, use it. If fiat only given, use BTC-XXX.
+        // If undefined, use BTC-USD.
+        if (strpos($currency, '-') !== false) {
+            $pair = $currency;
+        } else if ($currency) {
+            $pair = 'BTC-' . $currency;
+        } else {
+            $pair = 'BTC-USD';
         }
 
-        return $this->getAndMapMoney('/v2/prices/buy', $params);
+        return $this->getAndMapMoney('/v2/prices/' . $pair . '/buy', $params);
     }
 
     public function getSellPrice($currency = null, array $params = [])

--- a/src/Client.php
+++ b/src/Client.php
@@ -114,11 +114,15 @@ class Client
 
     public function getSellPrice($currency = null, array $params = [])
     {
-        if ($currency) {
-            $params['currency'] = $currency;
+        if (strpos($currency, '-') !== false) {
+            $pair = $currency;
+        } else if ($currency) {
+            $pair = 'BTC-' . $currency;
+        } else {
+            $pair = 'BTC-USD';
         }
 
-        return $this->getAndMapMoney('/v2/prices/sell', $params);
+        return $this->getAndMapMoney('/v2/prices/' . $pair . '/sell', $params);
     }
 
     public function getSpotPrice($currency = null, array $params = [])

--- a/tests/ClientIntegrationTest.php
+++ b/tests/ClientIntegrationTest.php
@@ -121,9 +121,23 @@ class ClientIntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('CAD', $data['currency']);
     }
 
-    public function testGetBuyPrice()
+    public function testGetBuyPrice1()
     {
         $price = $this->client->getBuyPrice();
+
+        $this->assertInstanceOf(Money::class, $price);
+    }
+
+    public function testGetBuyPrice2()
+    {
+        $price = $this->client->getBuyPrice('USD');
+
+        $this->assertInstanceOf(Money::class, $price);
+    }
+
+    public function testGetBuyPrice3()
+    {
+        $price = $this->client->getBuyPrice('ETH-USD');
 
         $this->assertInstanceOf(Money::class, $price);
     }

--- a/tests/ClientIntegrationTest.php
+++ b/tests/ClientIntegrationTest.php
@@ -128,9 +128,23 @@ class ClientIntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Money::class, $price);
     }
 
-    public function testGetSellPrice()
+    public function testGetSellPrice1()
     {
         $price = $this->client->getSellPrice();
+
+        $this->assertInstanceOf(Money::class, $price);
+    }
+
+    public function testGetSellPrice2()
+    {
+        $price = $this->client->getSellPrice('USD');
+
+        $this->assertInstanceOf(Money::class, $price);
+    }
+
+    public function testGetSellPrice3()
+    {
+        $price = $this->client->getSellPrice('ETH-USD');
 
         $this->assertInstanceOf(Money::class, $price);
     }

--- a/tests/ClientIntegrationTest.php
+++ b/tests/ClientIntegrationTest.php
@@ -149,9 +149,23 @@ class ClientIntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Money::class, $price);
     }
 
-    public function testGetSpotPrice()
+    public function testGetSpotPrice1()
     {
         $price = $this->client->getSpotPrice();
+
+        $this->assertInstanceOf(Money::class, $price);
+    }
+
+    public function testGetSpotPrice2()
+    {
+        $price = $this->client->getSpotPrice('USD');
+
+        $this->assertInstanceOf(Money::class, $price);
+    }
+
+    public function testGetSpotPrice3()
+    {
+        $price = $this->client->getSpotPrice('ETH-USD');
 
         $this->assertInstanceOf(Money::class, $price);
     }


### PR DESCRIPTION
Updates lib methods so users can specify asset (ETH-USD, BTC-USD, etc) instead of only BTC-USD, while maintaining backward compatibility for BTC-USD if no param is given.