### PR TITLE
Adding content-type = application/json as part of the default headers.

### DIFF
--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -185,6 +185,7 @@ class HttpClient
         $defaultHeaders = [
             'User-Agent' => 'coinbase/php/'.Client::VERSION,
             'CB-VERSION' => $this->apiVersion,
+            'Content-Type' => 'application/json',
         ];
 
         if (isset($params[Param::TWO_FACTOR_TOKEN])) {


### PR DESCRIPTION
Adding `content-type => application/json` as part of the default headers. This resolves issues with invalid signature errors for PUT and POST requests

Before this change whenever I tried a PUT or POST requests (i.e. PUT for change name of an account) I would get 

```
[GuzzleHttp\Exception\ClientException]
  Client error: `PUT https://api.coinbase.com/v2/accounts/[ACCOUNTGUID]` resulted in a `401 Unauthorized` response:
  {"errors":[{"id":"authentication_error","message":"invalid signature"}]}
```

once this change was added the name change went through successfully.